### PR TITLE
terminate run after completion

### DIFF
--- a/sendContent.ts
+++ b/sendContent.ts
@@ -49,7 +49,10 @@ const run = async () => {
 		await Aita.findOneAndUpdate(
 			{ url: post.url },
 			{ postId: id, datePosted: new Date() }
-		).then(() => console.log("donezo"));
+		).then(() => {
+			console.log("donezo");
+			process.exit();
+		});
 	});
 };
 run();


### PR DESCRIPTION
Previous script was not set to terminate after finishing the result reading. This fix resolves that oversight.